### PR TITLE
remove unnecessary fs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mdx2vast",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mdx2vast",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "@mdx-js/mdx": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@mdx-js/mdx": "^2.3.0",
                 "commander": "^11.0.0",
-                "fs": "^0.0.1-security",
                 "get-stdin": "^9.0.0",
                 "hast-util-to-html": "^9.0.5",
                 "hastscript": "^9.0.1",
@@ -1046,6 +1045,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
             "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2017,12 +2017,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
-        },
-        "node_modules/fs": {
-            "version": "0.0.1-security",
-            "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-            "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
-            "license": "ISC"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "dependencies": {
         "@mdx-js/mdx": "^2.3.0",
         "commander": "^11.0.0",
-        "fs": "^0.0.1-security",
         "get-stdin": "^9.0.0",
         "hast-util-to-html": "^9.0.5",
         "hastscript": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mdx2vast",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "CLI to convert MDX to HTML while preserving JSX and expressions.",
     "bin": {
         "mdx2vast": "bin/cli.js"


### PR DESCRIPTION
fs@0.0.1-security is only an empty placeholder to preserve the namespace (https://www.npmjs.com/package/fs). 
The package currently does nothing and exposes no code
<img width="869" height="494" alt="Screenshot 2026-01-02 at 16 06 12" src="https://github.com/user-attachments/assets/11513ff6-53ee-4ad0-bad4-5fb5975ca89c" />
<img width="887" height="302" alt="Screenshot 2026-01-02 at 16 06 17" src="https://github.com/user-attachments/assets/7f73516a-1c5e-48cc-8825-edd587587bc2" />

This is causing issues in our internal registry as we decided not to pull in `fs` as a package due to security concerns with the namespace being potentially used for malicious intent.